### PR TITLE
base.html: standings nav gets option for every year

### DIFF
--- a/espn_ffb/app.py
+++ b/espn_ffb/app.py
@@ -42,6 +42,11 @@ def number_format(value):
     return "{:,}".format(value)
 
 
+@app.context_processor
+def get_years():
+    return dict(years=query.get_distinct_years())
+
+
 @app.before_first_request
 def setup_logging():
     if not app.debug:

--- a/espn_ffb/db/query.py
+++ b/espn_ffb/db/query.py
@@ -309,6 +309,15 @@ class Query:
 
         return win_streaks
 
+    def get_distinct_years(self):
+      distinct_matchup_years = (
+        self.db.session.query(Matchups.year)
+        .distinct(Matchups.year)
+        .order_by(Matchups.year.desc())
+      )
+
+      return [matchup.year for matchup in distinct_matchup_years]
+
     def upsert_matchups(self, matchups):
         for m in matchups:
             statement = pg_insert(Matchups) \

--- a/espn_ffb/templates/base.html
+++ b/espn_ffb/templates/base.html
@@ -13,7 +13,9 @@
       <button class="dropbtn">Standings<i class="fa fa-caret-down"></i></button>
       <div class="dropdown-content">
         <a href="{{ url_for('standings.show', year='overall') }}">Overall</a>
-        <a href="{{ url_for('standings.show', year=2019) }}">2019</a>
+        {%- for year in years %}
+          <a href="{{ url_for('standings.show', year=year) }}">{{ year }}</a>
+        {%- endfor %}
       </div>
     </div>
     <a href="{{ url_for('h2h_records.show') }}" class="{% block nav_h2h %}{% endblock %}">H2H Records</a>


### PR DESCRIPTION
Introduces query.get_distinct_years as well as a
Flask context processor to expose the years to every
view for use in the nav bar

Example:

![image](https://user-images.githubusercontent.com/2746839/93262264-c6a36080-f758-11ea-85cd-cf3921441961.png)
