### PR TITLE
app.py: provide variables for nav construction

### DIFF
--- a/espn_ffb/app.py
+++ b/espn_ffb/app.py
@@ -15,6 +15,7 @@ from espn_ffb.views.playoffs import playoffs
 from espn_ffb.views.recap import recap
 from espn_ffb.views.standings import standings
 from flask import Flask, redirect
+import glob
 import logging
 import sys
 
@@ -47,9 +48,37 @@ def percentage_format(value):
     return "{:.4f}".format(value)
 
 
+def get_template_path_vars_for_nav(relative_path, pattern, splitter=None):
+    matching_paths = glob.glob(relative_path + pattern)
+
+    def remove_prefix(text, prefix=relative_path):
+        return text[text.startswith(prefix) and len(prefix):]
+
+    template_path_vars = []
+    for p in matching_paths:
+        path_var = remove_prefix(p)
+        path_var = path_var.strip(pattern)
+        if splitter:
+            path_var = tuple(int(p) for p in path_var.split(splitter))
+        template_path_vars.append(path_var)
+
+    return template_path_vars
+
+
 @app.context_processor
-def get_years():
-    return dict(years=query.get_distinct_years())
+def utility_processor():
+    return dict(
+        years=query.get_distinct_years(),
+        recap_templates_year_weeks=get_template_path_vars_for_nav(
+            "espn_ffb/templates/recap/", "*/*/", '/'
+        ),
+        playoffs_templates_years=get_template_path_vars_for_nav(
+            "espn_ffb/templates/playoffs/", "*.html"
+        ),
+        awards_templates_years=get_template_path_vars_for_nav(
+            "espn_ffb/templates/awards/", "*.html"
+        ),
+    )
 
 
 @app.before_first_request

--- a/espn_ffb/templates/base.html
+++ b/espn_ffb/templates/base.html
@@ -12,7 +12,7 @@
       <div class="dropdown {% block nav_awards %}{% endblock %}">
         <button class="dropbtn">Awards<i class="fa fa-caret-down"></i></button>
         <div class="dropdown-content">
-          {%- for year in awards_template_years %}
+          {%- for year in awards_templates_years %}
             <a href="{{ url_for('awards.show', year=year) }}">{{ year }}</a>
           {%- endfor %}
         </div>
@@ -44,7 +44,7 @@
       <div class="dropdown {% block nav_playoffs %}{% endblock %}">
         <button class="dropbtn">Playoffs<i class="fa fa-caret-down"></i></button>
         <div class="dropdown-content">
-          {%- for year in playoffs_template_years %}
+          {%- for year in playoffs_templates_years %}
             <a href="{{ url_for('playoffs.show', year=year) }}">{{ year }}</a>
           {%- endfor %}
         </div>

--- a/espn_ffb/templates/base.html
+++ b/espn_ffb/templates/base.html
@@ -8,14 +8,16 @@
     <script src="{{ url_for('static', filename='js/navbar.js') }}"></script>
   </head>
   <div class="topnav" id="myTopnav">
-    <div class="dropdown {% block nav_awards %}{% endblock %}">
-      <button class="dropbtn">Awards<i class="fa fa-caret-down"></i></button>
-      <div class="dropdown-content">
-        {%- for year in years %}
-          <a href="{{ url_for('awards.show', year=year) }}">{{ year }}</a>
-        {%- endfor %}
+    {%- if awards_templates_years %}
+      <div class="dropdown {% block nav_awards %}{% endblock %}">
+        <button class="dropbtn">Awards<i class="fa fa-caret-down"></i></button>
+        <div class="dropdown-content">
+          {%- for year in awards_template_years %}
+            <a href="{{ url_for('awards.show', year=year) }}">{{ year }}</a>
+          {%- endfor %}
+        </div>
       </div>
-    </div>
+    {%- endif %}
     <div class="dropdown {% block nav_standings %}{% endblock %}">
       <button class="dropbtn">Standings<i class="fa fa-caret-down"></i></button>
       <div class="dropdown-content">
@@ -27,19 +29,27 @@
     </div>
     <a href="{{ url_for('h2h_records.show') }}" class="{% block nav_h2h %}{% endblock %}">H2H Records</a>
     <a href="{{ url_for('matchup_history.show') }}" class="{% block nav_matchups %}{% endblock %}">Matchup History</a>
-    <div class="dropdown {% block nav_recap %}{% endblock %}">
-      <button class="dropbtn">Recap<i class="fa fa-caret-down"></i></button>
-      <div class="dropdown-content">
-        <a href="{{ url_for('recap.show', year=2018, week=2) }}">2018, Week 2</a>
+    {%- if recap_templates_year_weeks %}
+      <div class="dropdown {% block nav_recap %}{% endblock %}">
+        <button class="dropbtn">Recap<i class="fa fa-caret-down"></i></button>
+        <div class="dropdown-content">
+          {%- for year_month in recap_templates_year_weeks %}
+            <a href="{{ url_for('recap.show', year=year_month[0], week=year_month[1]) }}">{{ year_month[0] }}, Week {{ year_month[1] }}</a>
+          {%- endfor %}
+        </div>
       </div>
-    </div>
+    {%- endif %}
     <a href="{{ url_for('champions.show') }}" class="{% block nav_champions %}{% endblock %}">Champions</a>
-    <div class="dropdown {% block nav_playoffs %}{% endblock %}">
-      <button class="dropbtn">Playoffs<i class="fa fa-caret-down"></i></button>
-      <div class="dropdown-content">
-        <a href="{{ url_for('playoffs.show', year=2018) }}">2018</a>
+    {%- if playoffs_templates_years %}
+      <div class="dropdown {% block nav_playoffs %}{% endblock %}">
+        <button class="dropbtn">Playoffs<i class="fa fa-caret-down"></i></button>
+        <div class="dropdown-content">
+          {%- for year in playoffs_template_years %}
+            <a href="{{ url_for('playoffs.show', year=year) }}">{{ year }}</a>
+          {%- endfor %}
+        </div>
       </div>
-    </div>
+    {%- endif %}
     <a href="javascript:void(0);" style="font-size:15px;" class="icon" onclick="myFunction()">&#9776;</a>
   </div>
   {%- block content %}{% endblock %}


### PR DESCRIPTION
based on contents/existence of templates folder.

Removes the need to "hardcode" years and weeks
for templated Awards, Playoffs, and Recaps.

If these templates are absent removes nav option.
If templates are present builds the nav from those
that are available